### PR TITLE
Pin node 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node-16:alpine
+FROM node:16-alpine
 
 RUN apk add curl git rsync
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node-16:alpine
 
 RUN apk add curl git rsync
 


### PR DESCRIPTION
Pin Node 16 to prevent the renderer from breaking when Docker uses the latest version of Node which is now Node 17